### PR TITLE
Execute gtk-config in the docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,4 +79,10 @@ RUN ldconfig
 
 RUN export KMD_HOME=/usr/local/bin
 
-CMD [ "kmd", "-e" ]
+RUN chmod +x /usr/local/bin/gtk-config 
+
+WORKDIR /usr/local/bin/
+
+RUN ./gtk-config gtk
+
+CMD ["kmd", "-e"]


### PR DESCRIPTION
Hi, 

I have tried to run the docker image on a mac m1, kmd exited after the small splash screen.  
After some digging around I found that executing the script gtk-config which is inside the /usr/local/bin folder in the container fixes the problem.  I have added this to the Dockerfile. 

Not sure if this is specific to my enviroment. Please test on other enviroments prior to merging. 

Tested on:

- Mac m1 chip
- Docker version 20.10.14, build a224086349
- Mac os 12.6
- XQuartz 2.8.2

