### PR TITLE
Fix kmd was not starting 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,5 @@ RUN ./gtk-config gtk
 
 WORKDIR /
 
-CMD ["kmd", "-e"]
+CMD ["/usr/local/bin/kmd", "-e"]
+


### PR DESCRIPTION
Hi @jmshrv

Another fix. 

kmd only launches when you run it using the full absolute path for some reason. 
I think it worked last time becuase the workdir was set to /user/local/bin . However, this was changed to solve the file picker issue.

Basel.